### PR TITLE
Modify Dependency resolvePath to try require.resolve(...) convention first when path does not start with "." or "/"

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,7 +448,7 @@ __my-page.optimizer.json:__
 ```json
 {
     "dependencies": [
-        "style.less",
+        "./style.less",
         "require-run: ./main"
     ]
 }
@@ -487,7 +487,7 @@ A dependency can be described using a simple `String` path as shown in the follo
 
 ```json
 [
-    "style.less",
+    "./style.less",
     "../third-party/jquery.js",
     "**/*.css"
 ]
@@ -497,9 +497,9 @@ In the examples, the dependency type is inferred from the filename extension. Al
 
 ```json
 [
-    "style.less",
-    "less: style.less",
-    { "type": "less", "path": "style.less" }
+    "./style.less",
+    "less: ./style.less",
+    { "type": "less", "path": "./style.less" }
 ]
 ```
 
@@ -532,7 +532,7 @@ The Optimizer supports conditional dependencies. Conditional dependencies is a p
 ```json
 {
     "dependencies": [
-        { "path": "hello-mobile.js", "if-flag": "mobile" }
+        { "path": "./hello-mobile.js", "if-flag": "mobile" }
     ]
 }
 ```
@@ -541,7 +541,7 @@ Alternatively, you can also include the desktop version of a file if the "mobile
 ```json
 {
     "dependencies": [
-        { "path": "hello-desktop.js", "if-not-flag": "mobile" }
+        { "path": "./hello-desktop.js", "if-not-flag": "mobile" }
     ]
 }
 ```
@@ -552,7 +552,7 @@ If needed, a JavaScript expression can be used to describe a more complex condit
 {
     "dependencies": [
         {
-            "path": "hello-mobile.js",
+            "path": "./hello-mobile.js",
             "if": "flags.contains('phone') || flags.contains('tablet')"
         }
     ]
@@ -568,7 +568,7 @@ __Using the JavaScript API:__
 ```javascript
 pageOptimizer.optimizePage({
     dependencies: [
-        { path: 'hello-mobile.js', 'if-flag': 'mobile' }
+        { path: './hello-mobile.js', 'if-flag': 'mobile' }
     ],
     flags: ['mobile', 'foo', 'bar']
 })
@@ -626,7 +626,7 @@ You can also specify additional explicit dependencies if necessary:
 ```javascript
 require('raptor-loader').async(
     [
-        'style.less',
+        './style.less',
         'some/other/optimizer.json'
     ],
     function() {
@@ -648,7 +648,7 @@ You can also choose to declare async dependencies in an `optimizer.json` file:
         "my-module/lazy": [
             "require: foo",
             "require: bar",
-            "style.less",
+            "./style.less",
             "some/other/optimizer.json"
         ]
     }
@@ -681,7 +681,7 @@ optimizer.configure('optimizer-config.json');
 optimizer.optimizePage({
         name: 'my-page',
         dependencies: [
-            "style.less",
+            "./style.less",
             "require-run: ./main"
         ]
     },
@@ -728,10 +728,10 @@ var optimizer = require('optimizer');
 optimizer.optimizePage({
         name: 'my-page',
         dependencies: [
-            'foo.js',
-            'bar.js',
-            'baz.js',
-            'qux.css'
+            './foo.js',
+            './bar.js',
+            './baz.js',
+            './qux.css'
         ]
     },
     function(err, optimizedPage) {
@@ -808,10 +808,10 @@ _optimizer.json_:
 ```json
 {
     "dependencies": [
-        "jquery.js",
-        "foo.js",
-        "bar.js",
-        "style.less"
+        "./jquery.js",
+        "./foo.js",
+        "./bar.js",
+        "./style.less"
     ]
 }
 ```
@@ -1015,14 +1015,14 @@ Given the following configured bundles:
         {
             "name": "bundle1",
             "dependencies": [
-                "foo.js",
-                "baz.js"
+                "./foo.js",
+                "./baz.js"
             ]
         },
         {
             "name": "bundle2",
             "dependencies": [
-                "bar.js"
+                "./bar.js"
             ]
         }
     ]
@@ -1213,14 +1213,14 @@ This could also be expressed as a percentage:
 
             // Set of dependencies to add to the bundle
             "dependencies": [
-                "foo.js",
-                "baz.js"
+                "./foo.js",
+                "./baz.js"
             ]
         },
         {
             "name": "bundle2",
             "dependencies": [
-                "style/*.css",
+                "./style/*.css",
                 "require: **/*.js"
             ]
         }

--- a/lib/dependencies/Dependency.js
+++ b/lib/dependencies/Dependency.js
@@ -14,6 +14,7 @@ var lastModified = require('../last-modified');
 var DataHolder = require('raptor-async/DataHolder');
 var resolver = require('raptor-modules/resolver');
 var EventEmitter = require('events').EventEmitter;
+var cachingFs = require('../caching-fs');
 
 var NON_KEY_PROPERTIES = {
     inline: true,
@@ -64,6 +65,63 @@ function Dependency(dependencyConfig, dirname, filename) {
     this._events = undefined;
 
     this.set(dependencyConfig);
+}
+
+/**
+ * This function provides provides an implementation that is used by
+ * Dependency.prototype.resolvePath and Dependency.prototype.requireResolvePath.
+ * These functions will now use the same machenism for resolving paths which
+ * will work as follows:
+ *
+ * If path starts with "." then resolve as relative path.
+ * If path starts with "/" then path is absolute and has been resolved already.
+ * Otherwise, try to resolve path using NodeJS module search path convention
+ * and if that fails fallback to using relative path resolution.
+ */
+function Dependency_resolvePath(path, from) {
+    // NOTE: "this" is the Dependency
+    var dependency = this;
+    
+    if (!from) {
+        from = dependency.__dirname;
+    }
+
+    var firstChar = path.charAt(0);
+    if (firstChar === '.') {
+        // path is relative to dependency directory
+        return nodePath.resolve(from, path);
+    } else if (firstChar === '/') {
+        // path is absolute
+        return path;
+    } else {
+        // path should be resolved using require.resolve() convention first
+        // and attempt relative path resolution if that fails
+        try {
+            return resolver.serverResolveRequire(path, from);
+        } catch(e) {
+            // Not bothering to check error code since serverResolveRequire
+            // should only throw error for one reason which is "module not found".
+            // if (e.code === 'MODULE_NOT_FOUND') {
+            //
+            // }
+            var resolvedPath = nodePath.resolve(from, path);
+            
+            // Since the path looked like it was for a module we should check
+            // to see if the fallback technique actually found a file. If file
+            // does not exist for fallback path, then we'll report an error
+            // that the module does not exist by re-throwing the original error.
+            if (!cachingFs.existsSync(resolvedPath)) {
+                // Path is not a module or resolved path.
+                // Since the path did not start with a "." let's
+                // throw the error that we caught when trying to
+                // resolve as module
+                throw e;
+            }
+            
+            // We were able to r
+            return resolvedPath;
+        }
+    }
 }
 
 Dependency.prototype = {
@@ -154,41 +212,28 @@ Dependency.prototype = {
         }
     },
 
-    resolvePath: function(path) {
-        return nodePath.resolve(this.__dirname, path);
-    },
-
     /*
      * This resolve method will use the module search path to resolve
      * the given path if the path does not begin with "." or "/".
      *
-     * For example, dependency.requireResolvePath('some-module/a.js')
-     * will use the module search path starting from this dependencies directory.
+     * For example, dependency.resolvePath('some-module/a.js')
+     * will use the NodeJS module search path starting from this dependencies directory.
+     * If resolution fails using the NodeJS module search path, then an attempt
+     * will be made to resolve the path as a relative path.
      *
-     * dependency.requireResolvePath('./a.js') we resolved relative to the
+     * dependency.resolvePath('./a.js') we be resolved relative to the
      * directory of this dependency.
      *
-     * dependency.requireResolvePath('/a.js') is assumed to be absolute
+     * dependency.resolvePath('/a.js') is assumed to be absolute
      * (possibly because it was already resolved).
      */
-    requireResolvePath: function(path, from) {
-        if (!from) {
-            from = this.__dirname;
-        }
+    resolvePath: Dependency_resolvePath,
 
-        var firstChar = path.charAt(0);
-        if (firstChar === '.') {
-            // path is relative to this directory
-            return nodePath.resolve(from, path);
-        } else if (firstChar === '/') {
-            // path is absolute
-            // TODO: Should we use app-module-path?
-            return path;
-        } else {
-            // path should be resolved using require.resolve() convention
-            return resolver.serverResolveRequire(path, from);
-        }
-    },
+    /**
+     * @deprecated use resolvePath instead which has the same implementation
+     * (this is here for backward compatibility)
+     */
+    requireResolvePath: Dependency_resolvePath,
 
     getParentManifestDir: function() {
         return this.__dirname;

--- a/lib/dependencies/Dependency.js
+++ b/lib/dependencies/Dependency.js
@@ -15,6 +15,7 @@ var DataHolder = require('raptor-async/DataHolder');
 var resolver = require('raptor-modules/resolver');
 var EventEmitter = require('events').EventEmitter;
 var cachingFs = require('../caching-fs');
+var isAbsolute = require('../path').isAbsolute;
 
 var NON_KEY_PROPERTIES = {
     inline: true,
@@ -90,7 +91,7 @@ function Dependency_resolvePath(path, from) {
     if (firstChar === '.') {
         // path is relative to dependency directory
         return nodePath.resolve(from, path);
-    } else if (firstChar === '/') {
+    } else if (isAbsolute(path)) {
         // path is absolute
         return path;
     } else {
@@ -110,12 +111,17 @@ function Dependency_resolvePath(path, from) {
             // to see if the fallback technique actually found a file. If file
             // does not exist for fallback path, then we'll report an error
             // that the module does not exist by re-throwing the original error.
-            if (!cachingFs.existsSync(resolvedPath)) {
+            if (cachingFs.existsSync(resolvedPath)) {
+                // Fallback technique found the path.
+                // We might want to log something here to suggest that relative
+                // paths be prefixed with "." to avoid the extra work of trying to
+                // resolve path using NodeJS module search path.
+            } else {
                 // Path is not a module or resolved path.
                 // Since the path did not start with a "." let's
                 // throw the error that we caught when trying to
                 // resolve as module
-                throw e;
+                throw new Error('Failed to resolve path "' + path + '". Target file does not exist. Started search from directory "' + from + '".');
             }
             
             // We were able to r

--- a/test/optimizer-test.js
+++ b/test/optimizer-test.js
@@ -817,6 +817,46 @@ describe('optimizer/index', function() {
                 done();
             });
     });
+    
+    it('should allow for glob patterns with relative paths', function(done) {
+        var optimizer = require('../');
+        var pageOptimizer = optimizer.create({
+            fileWriter: {
+                outputDir: outputDir,
+                urlPrefix: '/',
+                fingerprintsEnabled: false
+            },
+            bundlingEnabled: true,
+            plugins: [
+                {
+                    plugin: 'optimizer-require',
+                    config: {
+                        includeClient: false
+                    }
+                }
+            ]
+        }, __dirname, __filename);
+
+        var writerTracker = require('./WriterTracker').create(pageOptimizer.writer);
+        pageOptimizer.optimizePage({
+                pageName: 'testPage',
+                dependencies: [
+                    './relative-paths.optimizer.json'
+                ],
+                from: path.join(__dirname, 'test-project-globs').replace(/\\/g, '/')
+            }, function(err, optimizedPage) {
+                if (err) {
+                    return done(err);
+                }
+
+                expect(writerTracker.getCodeForFilename('testPage.css')).to.equal(".style1 {}\n.style2 {}");
+                expect(writerTracker.getCodeForFilename('testPage.js')).to.contain("FOO");
+                expect(writerTracker.getCodeForFilename('testPage.js')).to.contain("BAR");
+                expect(writerTracker.getCodeForFilename('testPage.js')).to.contain("$rmod.def");
+
+                done();
+            });
+    });
 
     it('should generate unique filenames for non-file dependencies when bundling is disabled', function(done) {
         var optimizer = require('../');

--- a/test/test-project-globs/relative-paths.optimizer.json
+++ b/test/test-project-globs/relative-paths.optimizer.json
@@ -1,0 +1,6 @@
+{
+    "dependencies": [
+        "./style/*.css",
+        "require: ./require/*.js"
+    ]
+}


### PR DESCRIPTION
This is proposed fix for https://github.com/raptorjs/optimizer/issues/39